### PR TITLE
Recursive attribute accessors

### DIFF
--- a/thoth/lab/utils.py
+++ b/thoth/lab/utils.py
@@ -16,6 +16,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Various utilities for notebooks."""
+import typing
+
+from functools import partial
 
 from pkgutil import walk_packages
 from urllib.parse import urlparse
@@ -25,6 +28,9 @@ import urllib3
 
 import requests
 import pandas as pd
+
+
+DEFAULT = object()
 
 
 def obtain_location(name: str, verify: bool = False, only_netloc: bool = False) -> str:
@@ -98,3 +104,115 @@ def packages_info(thoth_packages: bool = True) -> pd.DataFrame:
         importable.append(import_successful)
 
     return pd.DataFrame(data={'package': packages, 'version': versions, 'importable': importable})
+
+
+def _rhas(fhas, fget, obj: typing.Any, attr: str) -> bool:
+    """Recursively check nested attributes of an object.
+
+    :param fhas: callable, function to be used as `hasattr`
+    :param fget: callable, function to be used as `getattr`
+    :param obj: Any, object to check
+    :param attr: str, attribute to find declared by dot notation accessor
+    :return: bool, whether the object has the given attribute
+    """
+    if isinstance(obj, list):
+        if not obj:  # empty list
+            return False
+
+        return any(_rhas(fhas, fget, item, attr) for item in obj)
+
+    try:
+        left, right = attr.split('.', 1)
+
+    except ValueError:
+        return fhas(obj, attr)
+
+    return _rhas(fhas, fget, fget(obj, left), right)
+
+
+def _rget(f,
+          obj: typing.Any,
+          attr: str,
+          repl_missing: typing.Any = None,
+          raise_if_missing: bool = False) -> typing.Any:
+    """Recursively retrieve nested attributes of an object.
+
+    :param f: callable, function to be used as `getattr`
+    :param obj: Any, object to check
+    :param attr: str, attribute to find declared by dot notation accessor
+    :param repl_missing: bool, whether to raise on missing attribute
+    :param raise_if_missing:
+    :return: Any, retrieved attribute
+    """
+    if isinstance(obj, (list, set)):
+        if len(obj) <= 0:
+            return None
+
+        return [
+            _rget(f, item, attr, repl_missing, raise_if_missing)
+            for item in obj
+        ]
+
+    right = ''
+    attrs = attr.split('.', 1)
+
+    if not attrs:
+        return obj
+    elif len(attrs) == 2:
+        left, right = attr.split('.', 1)
+    else:
+        left = attr
+
+    if not right:
+        try:
+            return f(obj, attr)
+
+        except (AttributeError, KeyError) as exc:
+            if raise_if_missing:
+                raise exc
+
+            return repl_missing
+
+    return _rget(f, f(obj, left), right, repl_missing, raise_if_missing)
+
+
+def has(obj, attr):
+    """Combine both `hasattr` and `in` into universal `has`."""
+    def _in(_obj, _attr):
+        try:
+            return _attr in _obj
+        except TypeError:
+            # object is not iterable
+            return False
+
+    return any([hasattr(obj, attr), _in(obj, attr)])
+
+
+def get(obj, attr, *, default: typing.Any = DEFAULT):
+    """Combine both `getattr` and `dict.get` into universal `get`."""
+    _getattr = getattr if default is DEFAULT else partial(getattr, default=default)
+    _get = dict.get if default is DEFAULT else partial(dict.get, default=default)
+
+    try:
+        return _getattr(obj, attr)
+
+    except AttributeError as exc:
+        if isinstance(obj, dict):
+            return _get(obj, attr, default, )
+        elif default is not DEFAULT:
+            return default
+
+        raise exc
+
+
+# syntactic sugar to _rhas and _rget which is meant for users
+
+rhasattr = partial(_rhas, hasattr, getattr)
+rhasattr.__doc__ = _rhas.__doc__
+rgetattr = partial(_rget, getattr)
+rgetattr.__doc__ = _rget.__doc__
+
+rhas = partial(_rhas, has, get)
+rhasattr.__doc__ = _rhas.__doc__
+rget = partial(_rget, get)
+rgetattr.__doc__ = _rget.__doc__


### PR DESCRIPTION
Recursive implementations of `hasattr` and `getattr` and some syntactic
sugar around it to make our lives easier.

These functions will later be used by the `Underscore` module in pandas-like fashion and will allow for flattening of nested dictionaries.

TODO: Make unit tests for `_rget` and `_rhas` functions

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   thoth/lab/utils.py