### PR TITLE
Move instantiation of classes

### DIFF
--- a/thoth/lab/common.py
+++ b/thoth/lab/common.py
@@ -67,7 +67,7 @@ def aggregate_thoth_results(
         files = []
 
     if not is_local:
-        files, counter = aggregate_thoth_results_from_ceph(files=files)
+        files, counter = aggregate_thoth_results_from_ceph(store_name=store_name, files=files)
 
     elif is_local:
         counter = 1
@@ -125,7 +125,7 @@ def aggregate_thoth_results(
     return files
 
 
-def aggregate_thoth_results_from_ceph(files: Union[dict, list]) -> Tuple[Union[dict, list], int]:
+def aggregate_thoth_results_from_ceph(store_name: str, files: Union[dict, list]) -> Tuple[Union[dict, list], int]:
     """Aggregate Thoth results from Ceph."""
     _STORE = {
         "inspection": InspectionResultsStore(),

--- a/thoth/lab/common.py
+++ b/thoth/lab/common.py
@@ -31,14 +31,6 @@ from zipfile import ZipFile
 
 _LOGGER = logging.getLogger("thoth.lab.common")
 
-_STORE = {
-    "inspection": InspectionResultsStore(),
-    "si-bandit": SIBanditResultsStore(),
-    "si-cloc": SIClocResultsStore(),
-    "solver": SolverResultsStore()
-}
-
-
 def extract_zip_file(file_path: Path):
     """Extract files from zip files."""
     with ZipFile(file_path, "r") as zip_file:
@@ -76,6 +68,12 @@ def aggregate_thoth_results(
     counter = 1
 
     if not is_local:
+        _STORE = {
+            "inspection": InspectionResultsStore(),
+            "si-bandit": SIBanditResultsStore(),
+            "si-cloc": SIClocResultsStore(),
+            "solver": SolverResultsStore()
+        }
         store = _STORE[store_name]
         store.connect()
 

--- a/thoth/lab/common.py
+++ b/thoth/lab/common.py
@@ -120,7 +120,7 @@ def aggregate_thoth_results(
 
                 counter += 1
 
-    _LOGGER.debug("Number of file retrieved is: %r" % counter)
+    _LOGGER.info("Number of file retrieved is: %r" % counter)
 
     return files
 


### PR DESCRIPTION
## Issues
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-26c97839f475> in <module>
      3 
      4 from pathlib import Path
----> 5 from thoth.lab import security

/opt/conda/lib/python3.7/site-packages/thoth/lab/security.py in <module>
     32 from thoth.python import Source
     33 
---> 34 from .common import aggregate_thoth_results
     35 
     36 _LOGGER = logging.getLogger("thoth.lab.security")

/opt/conda/lib/python3.7/site-packages/thoth/lab/common.py in <module>
     32 
     33 _STORE = {
---> 34     "si-bandit": SIBanditResultsStore(),
     35     "si-cloc": SIClocResultsStore(),
     36     "solver": SolverResultsStore()

/opt/conda/lib/python3.7/site-packages/thoth/storages/result_base.py in __init__(self, deployment_name, host, key_id, secret_key, bucket, region, prefix)
     56         ), "Make sure RESULT_TYPE in derived classes to distinguish between adapter type instances is non-empty."
     57 
---> 58         self.deployment_name = deployment_name or os.environ["THOTH_DEPLOYMENT_NAME"]
     59         self.prefix = "{}/{}/{}".format(
     60             prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.deployment_name, self.RESULT_TYPE

/opt/conda/lib/python3.7/os.py in __getitem__(self, key)
    677         except KeyError:
    678             # raise KeyError with the original key value
--> 679             raise KeyError(key) from None
    680         return self.decodevalue(value)
    681 

KeyError: 'THOTH_DEPLOYMENT_NAME'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements
Move instantion of classes to be started only if Ceph is required.